### PR TITLE
Add system monitor option to organization settings

### DIFF
--- a/rocket-bi-web/src/screens/organization-settings/views/OrganizationSettings.vue
+++ b/rocket-bi-web/src/screens/organization-settings/views/OrganizationSettings.vue
@@ -42,6 +42,13 @@ export default class OrganizationSettings extends LoggedInScreen {
         to: { name: Routers.SSO }
       },
       {
+        id: 'system_monitor',
+        displayName: 'System Monitor',
+        icon: 'di-icon-users',
+        to: { name: Routers.SystemMonitor },
+        disabled: EnvUtils.isDisableUserActivities()
+      },
+      {
         id: 'clickhouse_config',
         displayName: 'DataSource Config',
         icon: 'di-icon-my-data',


### PR DESCRIPTION
This commit introduces a new 'System Monitor' option to the organization settings menu. The option includes an icon and a navigation link, and its visibility is controlled by a utility function checking environment settings. This enhances the settings